### PR TITLE
Feature/devops task template

### DIFF
--- a/lib/rails/generators/rake_migrations/install_generator.rb
+++ b/lib/rails/generators/rake_migrations/install_generator.rb
@@ -18,7 +18,7 @@ module RakeMigrations
       end
 
       # devops task template
-      template("devops_list_pending_rake_tasks.rb", "lib/tasks/devops_list_pending_migrations.rb")
+      template("devops_rake_utils.rake", "lib/tasks/devops_rake_utils.rake")
 
       # commenting post merge hook as not required right now
       # write_to_post_merge_hook

--- a/lib/rails/generators/rake_migrations/install_generator.rb
+++ b/lib/rails/generators/rake_migrations/install_generator.rb
@@ -17,6 +17,9 @@ module RakeMigrations
         template("rake_migrations_check.rb", "lib/tasks/rake_migrations_check.rb")
       end
 
+      # devops task template
+      template("devops_list_pending_rake_tasks.rb", "lib/tasks/devops_list_pending_migrations.rb")
+
       # commenting post merge hook as not required right now
       # write_to_post_merge_hook
     end

--- a/lib/rails/generators/rake_migrations/templates/devops_list_pending_rake_tasks.rb
+++ b/lib/rails/generators/rake_migrations/templates/devops_list_pending_rake_tasks.rb
@@ -1,0 +1,8 @@
+require "#{Rails.root.to_s}/lib/tasks/rake_migrations_check"
+
+namespace :devops do
+  desc "Lists out all the non migrated rake tasks for an application"
+  task list_pending_rake_tasks: [:environment] do
+    RakeMigrationsCheck.check
+  end
+end

--- a/lib/rails/generators/rake_migrations/templates/devops_rake_utils.rake
+++ b/lib/rails/generators/rake_migrations/templates/devops_rake_utils.rake
@@ -1,6 +1,6 @@
 require "#{Rails.root.to_s}/lib/tasks/rake_migrations_check"
 
-namespace :devops do
+namespace :devops_rake_utils do
   desc "Lists out all the non migrated rake tasks for an application"
   task list_pending_rake_tasks: [:environment] do
     RakeMigrationsCheck.check


### PR DESCRIPTION
- Adding a template rake task for Devops to list out all the pending/non db mapped rake tasks present in the `lib/tasks/rake_migrations` dir
- The rake task is copied when the gem is installed into `lib/tasks`