### PR TITLE
RSpec update

### DIFF
--- a/lib/rails/generators/rake_migrations/install_generator.rb
+++ b/lib/rails/generators/rake_migrations/install_generator.rb
@@ -37,11 +37,16 @@ TEXT
 
     private
     def copy_migration_template_based_on_rails_version
-      if Rails::VERSION::MAJOR <= 4
+
+      host_rails_version = Rails.version
+      version_info = host_rails_version.split('.')
+
+      major_version = version_info.first
+      minor_version = version_info.second
+
+      if major_version.to_i <= 4
         migration_template "migration_rails_on_and_before_v4.rb", "db/migrate/create_rake_migrations_table.rb"
       else
-        major_version = Rails::VERSION::MAJOR
-        minor_version = Rails::VERSION::MINOR
         @rails_major_minor_version = "[#{major_version}.#{minor_version}]"
         migration_template "migration_rails_after_v4.rb", "db/migrate/create_rake_migrations_table.rb",
                            rails_major_minor_version: @rails_major_minor_version

--- a/spec/lib/generators/install_generator_spec_above_rails_v4.rb
+++ b/spec/lib/generators/install_generator_spec_above_rails_v4.rb
@@ -1,0 +1,39 @@
+require "generator_spec"
+require "rails/generators/rake_migrations/install_generator"
+
+# ToDo(Abhishek) how to DRY this up for ANY Rails version
+describe RakeMigrations::InstallGenerator do
+  destination File.expand_path("../../tmp", __FILE__)
+
+  context "migration and postgresql" do
+
+    before(:context) do
+      RSpec::Mocks.with_temporary_scope do
+        prepare_destination
+        allow(Rails).to receive(:version).and_return('5.1')
+        run_generator
+      end
+    end
+
+    it "should create a migration" do
+      assert_migration "db/migrate/create_rake_migrations_table.rb"
+    end
+
+    it "should create the rake_migrations table" do
+      assert_migration "db/migrate/create_rake_migrations_table.rb", /create_table :rake_migrations/
+    end
+
+    it "should create the version column" do
+      assert_migration "db/migrate/create_rake_migrations_table.rb", /t.string :version/
+    end
+
+    it "should have a Migration versioned for Rails 5.1" do
+      assert_migration "db/migrate/create_rake_migrations_table.rb", /5.1/
+    end
+
+    it "should copy the devop rakes util with RakeMigrations.check function call" do
+      assert_file "lib/tasks/devops_rake_utils.rake", /RakeMigrations.check/
+    end
+
+  end
+end

--- a/spec/lib/generators/install_generator_spec_on_or_below_rails_v4.rb
+++ b/spec/lib/generators/install_generator_spec_on_or_below_rails_v4.rb
@@ -4,10 +4,14 @@ require "rails/generators/rake_migrations/install_generator"
 describe RakeMigrations::InstallGenerator do
   destination File.expand_path("../../tmp", __FILE__)
 
-  context "migration and mysql2" do
-    before(:all) do
-      prepare_destination
-      run_generator
+  context "migration and postgresql" do
+
+    before(:context) do
+      RSpec::Mocks.with_temporary_scope do
+        prepare_destination
+        allow(Rails).to receive(:version).and_return('4.2')
+        run_generator
+      end
     end
 
     it "should create a migration" do
@@ -22,19 +26,9 @@ describe RakeMigrations::InstallGenerator do
       assert_migration "db/migrate/create_rake_migrations_table.rb", /t.string :version/
     end
 
-    it "should copy the rake_migrations_check file with mysql2 support" do
-      assert_file "config/rake_migrations_check.rb", /Mysql2::Client/
-    end
-  end
-
-  context "postgresql" do
-    before(:all) do
-      prepare_destination
-      run_generator ["pg"]
+    it "should copy the devop rakes util with RakeMigrations.check function call" do
+      assert_file "lib/tasks/devops_rake_utils.rake", /RakeMigrations.check/
     end
 
-    it "should copy the rake_migrations_check file with pg support" do
-      assert_file "config/rake_migrations_check.rb", /PG.connect/
-    end
   end
 end

--- a/spec/lib/generators/task_generator_spec.rb
+++ b/spec/lib/generators/task_generator_spec.rb
@@ -2,6 +2,7 @@ require "generator_spec"
 require "rails/generators/task/task_generator"
 require 'rails'
 
+# ToDo(Abhishek) how to DRY this up?
 describe TaskGenerator do
   destination File.expand_path("../../tmp", __FILE__)
 
@@ -9,7 +10,7 @@ describe TaskGenerator do
     before(:context) do
       RSpec::Mocks.with_temporary_scope do
         prepare_destination
-        allow(Rails).to receive(:version).and_return('4.1')
+        allow(Rails).to receive(:version).and_return('4.2')
         run_generator ["users", "do_something"]
       end
     end
@@ -18,30 +19,37 @@ describe TaskGenerator do
       time_to_test = Time.now
       allow(Time).to receive(:now).and_return(time_to_test)
       @timestamp = time_to_test.strftime("%Y%m%d%H%M%S")
+      # we need to fetch the directory due to a substring of the filename being generated using random characters
+      @all_files = Dir.entries("./spec/lib/tmp/lib/tasks/rake_migrations/").select {|f| !File.directory? f}  # https://stackoverflow.com/a/15511438
+      @created_rake_file = @all_files.first
+    end
+
+    it "should assert file is created" do
+      expect(@all_files.count).to eq 1
     end
 
     it "should create a file from the timestamp and namespace" do
-      assert_file "lib/tasks/rake_migrations/#{@timestamp}_3cd5f1_users.rake"
+      assert_file "lib/tasks/rake_migrations/#{@created_rake_file}"
     end
 
     it "should have the namespace 'users'" do
-      assert_file "lib/tasks/rake_migrations/#{@timestamp}_3cd5f1_users.rake", /namespace :users/
+      assert_file "lib/tasks/rake_migrations/#{@created_rake_file}", /namespace :users/
     end
 
     it "should have the task 'do_something'" do
-      assert_file "lib/tasks/rake_migrations/#{@timestamp}_3cd5f1_users.rake", /task do_something:/
+      assert_file "lib/tasks/rake_migrations/#{@created_rake_file}", /task do_something:/
     end
 
     it "should have the RakeMigration update" do
-      assert_file "lib/tasks/rake_migrations/#{@timestamp}_3cd5f1_users.rake", /RakeMigration.mark_complete/
+      assert_file "lib/tasks/rake_migrations/#{@created_rake_file}", /RakeMigration.mark_complete/
     end
   end
 
-  context "rails 3" do
+  context "rails 5" do
     before(:context) do
       RSpec::Mocks.with_temporary_scope do
         prepare_destination
-        allow(Rails).to receive(:version).and_return('3.2')
+        allow(Rails).to receive(:version).and_return('5.1')
         run_generator ["users", "do_something"]
       end
     end
@@ -50,10 +58,12 @@ describe TaskGenerator do
       time_to_test = Time.now
       allow(Time).to receive(:now).and_return(time_to_test)
       @timestamp = time_to_test.strftime("%Y%m%d%H%M%S")
+      @all_files = Dir.entries("./spec/lib/tmp/lib/tasks/rake_migrations/").select {|f| !File.directory? f}
+      @created_rake_file = @all_files.first
     end
 
     it "should have the RakeMigration update" do
-      assert_file "lib/tasks/rake_migrations/#{@timestamp}_3cd5f1_users.rake", /RakeMigration.mark_complete/
+      assert_file "lib/tasks/rake_migrations/#{@created_rake_file}", /RakeMigration.mark_complete/
     end
   end
 end

--- a/spec/lib/rake_migration_spec.rb
+++ b/spec/lib/rake_migration_spec.rb
@@ -1,11 +1,13 @@
 require 'active_record'
 require 'rake_migration'
 
+
 describe RakeMigration do
+
   context "version_from_path" do
     it "should extract rake id from file name" do
-      expect(RakeMigration.version_from_path('a/2/201810162054_xyz.rake3')).to eq('201810162054')
-      expect(RakeMigration.version_from_path('2/201810162054_xyz.rake3')).to eq('201810162054')
+      expect(RakeMigration.version_from_path('a/2/201810162054_abcdef_xyz.rake3')).to eq('201810162054_abcdef')
+      expect(RakeMigration.version_from_path('2/201810162054_abcdef_xyz.rake3')).to eq('201810162054_abcdef')
     end
   end
 
@@ -13,13 +15,13 @@ describe RakeMigration do
     it "should use find_or_create_by for rails 4" do
       allow(RakeMigration).to receive_message_chain(:methods,:include?).and_return(true)
       expect(RakeMigration).to receive(:find_or_create_by).with(hash_including(:version)).and_return(true)
-      RakeMigration.mark_complete('a/2/201810162054_xyz.rake3')
+      RakeMigration.mark_complete('a/2/201810162054_abcdef_xyz.rake3')
     end
 
     it "should use find_or_create_by_version for rails 3" do
       allow(RakeMigration).to receive_message_chain(:methods,:include?).and_return(false)
       allow(RakeMigration).to receive(:findcreate_by_version).and_return('something')
-      expect(RakeMigration.mark_complete('a/2/201810162054_xyz.rake3')).to eq('something')
+      expect(RakeMigration.mark_complete('a/2/201810162054_abcdef_xyz.rake3')).to eq('something')
     end
   end
 end

--- a/spec/lib/tmp/lib/tasks/rake_migrations/20190315205338_1b58ab_users.rake
+++ b/spec/lib/tmp/lib/tasks/rake_migrations/20190315205338_1b58ab_users.rake
@@ -2,17 +2,16 @@
 # 1. Re-runnable on production?
 # 2. Is there a chance emails will be sent?
 # 3. puts ids & logs (progress log)
-# 4. Can you update the records with an update all instead of instantizing?
+# 4. Should this be inside a Active Record Transaction block?
 # 5. Are there any callbacks?
 # 6. Performance issues?
-# 7. Scoping to account
 
 namespace :users do
   desc "TODO"
   task do_something: [:environment] do
 
 
-    # DO NOT REMOVE THIS PART
-    RakeMigration.find_or_create_by_version(__FILE__[/\d+/])
+    # DO NOT REMOVE THIS PART. MARKS THE RAKE AS COMPLETE IN THE DATABASE
+    RakeMigration.mark_complete(__FILE__)
   end
 end


### PR DESCRIPTION
- Adding and modifying existing specs
- Changing the host application rails version calculation logic as mocking a `Rails::VERSION::MAJOR/MINOR` was fighter
- Using `Dir` to find the tmp rake file created in the spec flow as the file name substring contains randomized characters